### PR TITLE
Rule To Check X-UA-Compatible

### DIFF
--- a/src/config/Rules.yml
+++ b/src/config/Rules.yml
@@ -12,6 +12,13 @@ Rules:
             - ["setHeaderToSearchFor", ["X-XSS-Protection"]]
             - ["setValue", ["1; mode=block"]]
 
+    HttpHeaderUXCompatible:
+        class: \Frickelbruder\KickOff\Rules\HttpHeaderHasValue
+        calls:
+            - ["setName", ["HttpHeaderUXCompatible"]]
+            - ["setHeaderToSearchFor", ["X-UA-Compatible"]]
+            - ["setValue", ["ie=edge"]]
+
     HttpHeaderExposeLanguage:
         class: \Frickelbruder\KickOff\Rules\HttpHeaderNotPresent
         calls:

--- a/tests/Rules/ConfiguredRules/DefaultConfiguredRuleTestBase.php
+++ b/tests/Rules/ConfiguredRules/DefaultConfiguredRuleTestBase.php
@@ -49,6 +49,7 @@ class DefaultConfiguredRuleTestBase extends \PHPUnit_Framework_TestCase {
 
         $this->defaultHeaders = array(
             'X-XSS-Protection' => '1; mode=block',
+            'X-UA-Compatible' => 'ie=edge',
             'X-Content-Type-Options' => 'nosniff',
             'X-Frame-Options' => 'SAMEORIGIN',
             'Set-Cookie' => 'PHPSESSID=SESSION; path=/; expires=WHENEVER; secure; HttpOnly',

--- a/tests/Rules/ConfiguredRules/HttpHeaderUXCompatibleTest.php
+++ b/tests/Rules/ConfiguredRules/HttpHeaderUXCompatibleTest.php
@@ -1,0 +1,13 @@
+<?php
+namespace Frickelbruder\KickOff\Tests\Rules\ConfiguredRules;
+
+class HttpHeaderUXCompatibleTestBase extends DefaultConfiguredRuleTestBase {
+
+    public function testValidate() {
+        $this->defaultValidateTest('HttpHeaderUXCompatible');
+    }
+
+    public function testValidateError() {
+        $this->defaultValidateErrorTest('HttpHeaderUXCompatible');
+    }
+}

--- a/tests/Rules/ConfiguredRules/files/configuredRules.yml
+++ b/tests/Rules/ConfiguredRules/files/configuredRules.yml
@@ -40,3 +40,6 @@ Sections:
     HttpHeaderHSTSWithSubdomains:
         rules:
             - HttpHeaderHSTSWithSubdomains
+    HttpHeaderUXCompatible:
+        rules:
+            - HttpHeaderUXCompatible


### PR DESCRIPTION
Added a rule to check the `X-UA-Compatible` header is set to `ie=edge` as requested in #13 