### PR TITLE
Update error output

### DIFF
--- a/src/Http/HttpRequester.php
+++ b/src/Http/HttpRequester.php
@@ -3,6 +3,7 @@ namespace Frickelbruder\KickOff\Http;
 
 use Frickelbruder\KickOff\Configuration\TargetUrl;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Client;
 
@@ -48,12 +49,23 @@ class HttpRequester {
             $response->setStatus( $websiteResponse->getStatusCode() );
         } catch(ClientException $e) {
             $websiteResponse = $e->getResponse();
+        } catch(ConnectException $e) {
+            $websiteResponse = false;
+            $exceptionMessage = $e->getMessage();
         }
-        $headers = $this->prepareResponseHeaders( $websiteResponse->getHeaders() );
-        $response->setHeaders( $headers );
+
+        if ($websiteResponse) {
+            $headers = $this->prepareResponseHeaders( $websiteResponse->getHeaders() );
+            $response->setHeaders( $headers );
+            $response->setBody( $websiteResponse->getBody() );
+            $response->setStatus( $websiteResponse->getStatusCode() );
+        } else {
+//            $headers = $this->prepareResponseHeaders( $websiteResponse->getHeaders() );
+//            $response->setHeaders( $headers );
+            $response->setBody( $exceptionMessage );
+            $response->setStatus( 404 );
+        }
         $response->setRequest($targetUrl);
-        $response->setBody( $websiteResponse->getBody() );
-        $response->setStatus( $websiteResponse->getStatusCode() );
 
         return $response;
     }

--- a/src/Log/Listener/ConsoleOutputListener.php
+++ b/src/Log/Listener/ConsoleOutputListener.php
@@ -15,8 +15,13 @@ class ConsoleOutputListener implements Listener {
 
     private $counter = array('success' => 0, 'errors' => 0);
 
+    private $outputPadLength = 0;
+    private $outputPadMinLength = 80;
+    private $padOutputToLongestMessage = true;
+
     public function __construct() {
         $this->consoleOutput = new ConsoleOutput();
+        $this->outputPadLength = $this->outputPadMinLength;
     }
 
 
@@ -24,7 +29,9 @@ class ConsoleOutputListener implements Listener {
         $output = '.';
         $counterToUpdate = 'success';
         if(!$success) {
-            $this->messages[] =  $rule->getErrorMessage() . '(' . $sectionName. ':' . $rule->getName() . ')';
+            $message = $rule->getReadableName() . ': ' . $rule->getErrorMessage();
+            $this->updatePadLength($message);
+            $this->messages[ucwords($sectionName)][] = $message;
             $output = '<error>F</error>';
             $counterToUpdate = 'errors';
         }
@@ -34,9 +41,14 @@ class ConsoleOutputListener implements Listener {
 
     public function finish() {
         $this->consoleOutput->writeln("");
-        foreach($this->messages as $message) {
-            $this->consoleOutput->writeln('<error>'.$message.'</error>');
+        foreach($this->messages as $section=>$messages) {
+            $this->consoleOutput->writeln('<error>'.str_pad('', $this->outputPadLength).'</error>');
+            $this->consoleOutput->writeln('<error>'.str_pad('  '.$section.'  ', $this->outputPadLength).'</error>');
+            foreach ($messages as $message) {
+                $this->consoleOutput->writeln('<error>'.str_pad('    '.$message.'  ', $this->outputPadLength).'</error>');
+            }
         }
+        $this->consoleOutput->writeln('<error>'.str_pad('', $this->outputPadLength).'</error>');
         $this->consoleOutput->writeln("");
 
         $totalTests = $this->counter['success'] + $this->counter['errors'];
@@ -48,4 +60,9 @@ class ConsoleOutputListener implements Listener {
         $this->consoleOutput->writeln($message);
     }
 
+    private function updatePadLength($message='') {
+        if ($this->padOutputToLongestMessage && (strlen($message)>$this->outputPadLength)) {
+            $this->outputPadLength = strlen($message)+6;
+        }
+    }
 }

--- a/src/Rules/AppleTouchIcon.php
+++ b/src/Rules/AppleTouchIcon.php
@@ -3,9 +3,11 @@ namespace Frickelbruder\KickOff\Rules;
 
 class AppleTouchIcon extends RuleBase {
 
+    public $name = 'AppleTouchIcon';
+
     protected $xpath = '/html/head/link[@rel="apple-touch-icon"]';
 
-    protected $errorMessage = 'No apple touch icon meta header was not.';
+    protected $errorMessage = 'No apple touch icon meta header was found.';
 
     public function validate() {
 

--- a/src/Rules/MetaGeneratorNotPresent.php
+++ b/src/Rules/MetaGeneratorNotPresent.php
@@ -5,7 +5,7 @@ class MetaGeneratorNotPresent extends HtmlTagNotPresent {
 
     public $name = 'MetaGeneratorNotPresent';
 
-    protected $errorMessage = 'The <meta name="generator" content="..."> tag must nor be present.';
+    protected $errorMessage = 'The <meta name="generator" content="..."> tag must not be present.';
 
     protected $xpath = '/html/head/meta[@name="generator"]/ @content';
 

--- a/src/Rules/RuleBase.php
+++ b/src/Rules/RuleBase.php
@@ -29,6 +29,17 @@ abstract class RuleBase implements RuleInterface {
         return $this->name;
     }
 
+    public function getReadableName() {
+        $regex = '/(?#! splitCamelCase Rev:20140412)
+            # Split camelCase "words". Two global alternatives. Either g1of2:
+              (?<=[a-z])      # Position is after a lowercase,
+              (?=[A-Z])       # and before an uppercase letter.
+            | (?<=[A-Z])      # Or g2of2; Position is after uppercase,
+              (?=[A-Z][a-z])  # and before upper-then-lower case.
+            /x';
+        return implode(' ',preg_split($regex, ucfirst($this->name)));
+    }
+
     /**
      * @param string $name
      */


### PR DESCRIPTION
Make the error output a bit cleaner:
 - Added padding around messages
 - Added section titles
 - Converted error names from Pascal Case to space-separated words

Also added a catch of the error message from guzzlehttp when the url does not exist, such as cdn.someurl.com