### PR TITLE
 Add a rule that checks for H1 tags 

### DIFF
--- a/example/seo.yml
+++ b/example/seo.yml
@@ -10,6 +10,7 @@ Sections:
             - MetaDescriptionLength
             - LinkHrefLang
             - LinkRelCanonical
+            - H1TagPresent
             - HttpRequestTime:
                 - ["maxTransferTime", 1500]
 

--- a/src/Rules/H1TagPresent.php
+++ b/src/Rules/H1TagPresent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Frickelbruder\KickOff\Rules;
+
+class H1TagPresent extends ConfigurableRuleBase {
+
+    public $name = 'H1TagPresent';
+
+    protected $allowMultipleTags = true;
+
+    public function validate()
+    {
+        $body   = $this->httpResponse->getBody();
+        $xml    = $this->getResponseBodyAsXml($body);
+        $amount = count($xml->xpath('//h1'));
+
+        if (!$this->allowMultipleTags && $amount > 1) {
+            $this->errorMessage = 'More than one H1 tag exists on this page.';
+            return false;
+        }
+
+        if ($amount == 0) {
+            $this->errorMessage = 'This page does not contain an H1 tag.';
+            return false;
+        }
+
+        return true;
+    }
+
+    public function allowMultipleTags($allowMultipleTags)
+    {
+        $this->allowMultipleTags = $allowMultipleTags;
+    }
+}

--- a/src/config/Rules.yml
+++ b/src/config/Rules.yml
@@ -120,4 +120,13 @@ Rules:
         calls:
             - ["setName", ["FindStringOnWebsite"]]
 
+    H1TagPresent:
+        class: \Frickelbruder\KickOff\Rules\H1TagPresent
+        calls:
+            - ["setName", ["H1TagPresent"]]
 
+    ExactlyOneH1TagPresent:
+        class: \Frickelbruder\KickOff\Rules\H1TagPresent
+        calls:
+            - ["setName", ["ExactlyOneH1TagPresent"]]
+            - ["allowMultipleTags", [false]]

--- a/src/config/Seo.yml
+++ b/src/config/Seo.yml
@@ -15,3 +15,4 @@ Sections:
             - LinkHrefLang
             - AppleTouchIcon
             - MetaGeneratorNotPresent
+            - H1TagPresent

--- a/tests/Rules/H1TagPresentTest.php
+++ b/tests/Rules/H1TagPresentTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Frickelbruder\KickOff\Tests\Rules;
+
+use Frickelbruder\KickOff\Http\HttpResponse;
+use Frickelbruder\KickOff\Rules\H1TagPresent;
+
+class H1TagPresentTest extends \PHPUnit_Framework_TestCase
+{
+
+    const NO_H1_TAG = '<!DOCTYPE html><html><body><p>Foo</p></body></html>';
+
+    const ONE_H1_TAG = '<!DOCTYPE html><html><body><h1>Foo</h1><p>Bar</p></body></html>';
+
+    const TWO_H1_TAGS = '<!DOCTYPE html><html><body><h1>Foo</h1><p>Bar</p><h1>Lorem</h1><p>Ipsum</p></body></html>';
+
+
+    public function testDetectsMissingH1Tag()
+    {
+        $results = $this->validateString(self::NO_H1_TAG);
+
+        $this->assertFalse($results['result']);
+        $this->assertFalse($results['strictResult']);
+    }
+
+
+    public function testDetectsMultipleH1Tags()
+    {
+        $results = $this->validateString(self::TWO_H1_TAGS);
+
+        $this->assertTrue($results['result']);
+        $this->assertFalse($results['strictResult']);
+    }
+
+
+    public function testSucceedsWhenExactlyOneH1TagExists()
+    {
+        $results = $this->validateString(self::ONE_H1_TAG);
+
+        $this->assertTrue($results['result']);
+        $this->assertTrue($results['strictResult']);
+    }
+
+
+    private function validateString($testString)
+    {
+        $response = new HttpResponse();
+        $response->setBody($testString);
+
+        $rule = new H1TagPresent();
+        $rule->setHttpResponse($response);
+
+        $strictRule = new H1TagPresent();
+        $strictRule->setHttpResponse($response);
+        $strictRule->allowMultipleTags(false);
+
+        return [
+            'result'       => $rule->validate(),
+            'strictResult' => $strictRule->validate(),
+        ];
+    }
+}


### PR DESCRIPTION
This rule ensures that a `<h1>` tag is present on a tested page.

There seems to be a war of opinions on whether or not multiple `<h1>` tags are acceptable on a single page. Therefore this PR also comes with the `ExactlyOneH1TagPresent` rule.

By default, multiple top-level headlines are acceptable.