### PR TITLE
Use the Symfony DomCrawler component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "php": ">=5.5.0",
     "symfony/yaml": "~2",
     "symfony/console": "~2",
-    "guzzlehttp/guzzle": "~6"
+    "guzzlehttp/guzzle": "~6",
+    "symfony/dom-crawler": "~2.8",
+    "symfony/css-selector": "~2.8"
   },
   "require-dev": {
     "phpunit/phpunit": "~4"

--- a/src/Rules/AppleTouchIcon.php
+++ b/src/Rules/AppleTouchIcon.php
@@ -5,25 +5,26 @@ class AppleTouchIcon extends RuleBase {
 
     public $name = 'AppleTouchIcon';
 
-    protected $xpath = '/html/head/link[@rel="apple-touch-icon"]';
+    protected $xpath = './html/head/link[@rel="apple-touch-icon"]';
 
     protected $errorMessage = 'No apple touch icon meta header was found.';
 
     public function validate() {
 
-        $icons = $this->getDomElementFromBodyByXpath($this->xpath);
-
+        $icons = $this->getCrawler()->filterXPath($this->xpath);
+        $sizeAttributes = $icons->extract(['sizes']);
         $foundItems = array();
-        foreach($icons as $icon) {
-            $size = empty($icon['sizes']) ? 'default' : (string) $icon['sizes'][0];
-            if(isset($foundItems[$size])) {
+
+        foreach ($sizeAttributes as $size) {
+            if (isset($foundItems[$size])) {
                 $this->errorMessage = 'Multiple apple-touch-icon entries for size "' . $size . '" found.';
                 return false;
             }
-            $foundItems[$size] = $icon;
+
+            $foundItems[$size] = $size;
         }
 
-        return !empty($icons);
+        return count($icons) > 0;
     }
 
 

--- a/src/Rules/H1TagPresent.php
+++ b/src/Rules/H1TagPresent.php
@@ -10,9 +10,7 @@ class H1TagPresent extends ConfigurableRuleBase {
 
     public function validate()
     {
-        $body   = $this->httpResponse->getBody();
-        $xml    = $this->getResponseBodyAsXml($body);
-        $amount = count($xml->xpath('//h1'));
+        $amount = count($this->getCrawler()->filter('h1'));
 
         if (!$this->allowMultipleTags && $amount > 1) {
             $this->errorMessage = 'More than one H1 tag exists on this page.';

--- a/src/Rules/HtmlTagNotPresent.php
+++ b/src/Rules/HtmlTagNotPresent.php
@@ -8,9 +8,9 @@ class HtmlTagNotPresent extends ConfigurableRuleBase {
     protected $configurableField = array('xpath');
 
     public function validate() {
-        $result = $this->getDomElementFromBodyByXpath($this->xpath);
+        $tags = $this->getCrawler()->filterXPath($this->xpath);
 
-        return empty($result);
+        return !count($tags);
     }
 
 

--- a/src/Rules/LinkHrefLang.php
+++ b/src/Rules/LinkHrefLang.php
@@ -149,17 +149,16 @@ class LinkHrefLang extends RuleBase {
     }
 
     private function getNormalizedBodyItems() {
-        $hrefLangItems = $this->getDomElementFromBodyByXpath('/html/head/link[@rel="alternate"][@hreflang]');
-        if(!is_array($hrefLangItems)) {
-            return array();
-        }
         $normalizedItems = array();
-        foreach($hrefLangItems as $hrefLangItem) {
+        $hrefLangItems = $this->getCrawler()->filterXPath('./html/head/link[@rel="alternate"][@hreflang]');
+
+        foreach ($hrefLangItems->extract(['hreflang', 'href']) as $values) {
             $normalizedItems[] = array(
-                'hreflang' => (string) $hrefLangItem['hreflang'],
-                'href' => (string) $hrefLangItem['href']
+                'hreflang' => $values[0],
+                'href' => $values[1]
             );
         }
+
         return $normalizedItems;
     }
 

--- a/src/Rules/MetaDescriptionLength.php
+++ b/src/Rules/MetaDescriptionLength.php
@@ -14,12 +14,12 @@ class MetaDescriptionLength extends ConfigurableRuleBase {
     protected $errorMessage = 'The meta description on this page does not have the required length.';
 
     public function validate() {
-        $metaDescriptionValue = $this->getDomElementFromBodyByXpath('/html/head/meta[@name="description"]/ @content');
-        if(!is_array($metaDescriptionValue) || empty($metaDescriptionValue)) {
+        $metaDescriptionElement = $this->getCrawler()->filterXPath('./html/head/meta[@name="description"]');
+        if (!count($metaDescriptionElement)) {
             $this->errorMessage = 'No meta description found';
             return false;
         }
-        $length = mb_strlen( $metaDescriptionValue[0]['content'], 'UTF-8' );
+        $length = mb_strlen( $metaDescriptionElement->eq(0)->attr('content'), 'UTF-8' );
 
         if($length < $this->minlength) {
             $this->errorMessage = 'The meta description is too short.';

--- a/src/Rules/MetaGeneratorNotPresent.php
+++ b/src/Rules/MetaGeneratorNotPresent.php
@@ -7,6 +7,6 @@ class MetaGeneratorNotPresent extends HtmlTagNotPresent {
 
     protected $errorMessage = 'The <meta name="generator" content="..."> tag must not be present.';
 
-    protected $xpath = '/html/head/meta[@name="generator"]/ @content';
+    protected $xpath = './html/head/meta[@name="generator"]';
 
 }

--- a/src/Rules/OgPropertyPresent.php
+++ b/src/Rules/OgPropertyPresent.php
@@ -12,26 +12,16 @@ class OgPropertyPresent extends ConfigurableRuleBase {
     protected $configurableField = array( 'requiredProperties' );
 
     public function validate() {
-        $body = $this->httpResponse->getBody();
-        $xml = $this->getResponseBodyAsXml( $body );
+        $crawler = $this->getCrawler();
 
-        return $this->checkRequiredProperties( $xml );
-    }
-
-    /**
-     * @param \SimpleXMLElement $body
-     *
-     * @return bool
-     */
-    private function checkRequiredProperties($body) {
         foreach( $this->requiredProperties as $propertyName ) {
-            $propertyItemValue = $body->xpath( '/html/head/meta[@property="og:' . $propertyName . '"]/ @content' );
-            if( !is_array( $propertyItemValue ) || empty( $propertyItemValue ) ) {
+            $propertyElement = $crawler->filterXPath( './html/head/meta[@property="og:' . $propertyName . '"]' );
+            if(!count($propertyElement)) {
                 $this->errorMessage = 'The open graph property "' . $propertyName . '" was not found on the site.';
 
                 return false;
             }
-            $length = mb_strlen( $propertyItemValue[0]['content'], 'UTF-8' );
+            $length = mb_strlen( $propertyElement->eq(0)->attr('content'), 'UTF-8' );
 
             if( $length == 0 ) {
                 $this->errorMessage = 'The open graph property "' . $propertyName . '" was found but is empty.';

--- a/src/Rules/RuleBase.php
+++ b/src/Rules/RuleBase.php
@@ -3,6 +3,7 @@ namespace Frickelbruder\KickOff\Rules;
 
 use Frickelbruder\KickOff\Http\HttpResponse;
 use Frickelbruder\KickOff\Rules\Exceptions\HeaderNotFoundException;
+use Symfony\Component\DomCrawler\Crawler;
 
 abstract class RuleBase implements RuleInterface {
 
@@ -51,28 +52,22 @@ abstract class RuleBase implements RuleInterface {
         return $this->errorMessage;
     }
 
-    /**
-     * @param string $body
-     *
-     * @return \SimpleXMLElement
-     */
-    protected function getResponseBodyAsXml($body) {
-        libxml_use_internal_errors( true );
-        $doc = new \DOMDocument();
-        $doc->strictErrorChecking = false;
-        $doc->loadHTML( '<?xml encoding="utf-8" ?>' . $body );
-        $xml = simplexml_import_dom( $doc );
-
-        return $xml;
-    }
-
-    protected function getDomElementFromBodyByXpath($xpath) {
+    protected function getCrawler()
+    {
         $body = $this->httpResponse->getBody();
-        if(empty($body)) {
-            return '';
+        $contentType = null;
+
+        foreach ($this->httpResponse->getHeaders() as $key => $value) {
+            if (strtolower($key) == 'content-type') {
+                $contentType = $value[0];
+                break;
+            }
         }
-        $xml = $this->getResponseBodyAsXml( $body );
-        return $xml->xpath($xpath);
+
+        $crawler = new Crawler();
+        $crawler->addContent($body, $contentType);
+
+        return $crawler;
     }
 
     protected function findHeader($headerName) {

--- a/src/Rules/TitleTagLength.php
+++ b/src/Rules/TitleTagLength.php
@@ -14,17 +14,14 @@ class TitleTagLength extends ConfigurableRuleBase {
     protected $errorMessage = 'The title tag on this page does not have the required length.';
 
     public function validate() {
-        $body = $this->httpResponse->getBody();
-        $xml = $this->getResponseBodyAsXml( $body );
+        $titleTag = $this->getCrawler()->filterXPath('./html/head/title');
 
-        $titleTagValue = $xml->head->title;
-
-        if( empty( $titleTagValue ) ) {
+        if (!count($titleTag)) {
             $this->errorMessage = 'The title tag was not found.';
 
             return false;
         }
-        ( $length = mb_strlen( $titleTagValue, 'UTF-8' ) );
+        ( $length = mb_strlen( $titleTag->text(), 'UTF-8' ) );
 
         if( $length < $this->minlength ) {
             $this->errorMessage = 'The title tag is too short.';

--- a/src/Rules/TwitterProperty.php
+++ b/src/Rules/TwitterProperty.php
@@ -14,27 +14,17 @@ class TwitterProperty extends ConfigurableRuleBase {
     protected $configurableField = array( 'requiredProperties' );
 
     public function validate() {
-        $body = $this->httpResponse->getBody();
-        $xml = $this->getResponseBodyAsXml( $body );
+        $crawler = $this->getCrawler();
 
-        return $this->checkRequiredProperties( $xml );
-    }
-
-    /**
-     * @param \SimpleXMLElement $body
-     *
-     * @return bool
-     */
-    private function checkRequiredProperties($body) {
         foreach( $this->requiredProperties as $propertyName ) {
-            $propertyItemValue = $body->xpath( '/html/head/meta[@name="twitter:' . $propertyName . '"]/ @content' );
-            if( !is_array( $propertyItemValue ) || empty( $propertyItemValue ) ) {
+            $propertyElement = $crawler->filterXPath( './html/head/meta[@name="twitter:' . $propertyName . '"]' );
+            if (!count($propertyElement)) {
                 $this->errorMessage = 'The twitter property "' . $propertyName . '" was not found on the site.';
 
                 return false;
             }
 
-            if(!$this->validateProperty($propertyName, $propertyItemValue[0]['content'])) {
+            if(!$this->validateProperty($propertyName, $propertyElement->attr('content'))) {
                 return false;
             }
         }

--- a/tests/Rules/MetaDescriptionLengthTest.php
+++ b/tests/Rules/MetaDescriptionLengthTest.php
@@ -81,6 +81,7 @@ class MetaDescriptionLengthTest extends \PHPUnit_Framework_TestCase {
     public function testValidateAsUtf8() {
         $response = new HttpResponse();
         $response->setBody('<!DOCTYPE html><html><head><meta name="description" content="äöü"></head></html>');
+        $response->setHeaders(['Content-Type' => ['text/html; charset=UTF-8']]);
 
         $rule = new MetaDescriptionLength();
         $rule->set('minlength', 2);

--- a/tests/Rules/TitleTagLengthTest.php
+++ b/tests/Rules/TitleTagLengthTest.php
@@ -67,6 +67,7 @@ class TitleTagLengthTest extends \PHPUnit_Framework_TestCase {
     public function testValidateAsUtf8() {
         $response = new HttpResponse();
         $response->setBody('<!DOCTYPE html><html><head><title>öäü</title></head></html>');
+        $response->setHeaders(['Content-Type' => ['text/html; charset=UTF-8']]);
 
         $rule = new TitleTagLength();
         $rule->set('minlength', 2);


### PR DESCRIPTION
This PR replaces the “homemade” HTML parsing using both the DOM and the SimpleXML extensions with Symfony’s DomCrawler component:
https://symfony.com/doc/current/components/dom_crawler.html

That component offers an even nicer API for filtering and traversing through an XML or DOM tree, such as an option to use CSS selectors instead of XPath.

Another problem that’s rather implicitly fixed by this change is the default charset: According to the HTTP/1.1 specification, ISO-8859-1 should be assumed if nothing else is specified. (“When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP.”)

The old implementation used UTF-8 as a default instead and would even ignore a charset defined by the HTTP Content-Type header.

I had to adjust two test cases (`TitleTagLengthTest` and `MetaDescriptionLengthTest`) to properly handle that change.