### PR TITLE
Detect invalid SSL certificate

### DIFF
--- a/src/Http/HttpRequester.php
+++ b/src/Http/HttpRequester.php
@@ -58,7 +58,7 @@ class HttpRequester {
             // a website with an invalid certificate can still be checked.
             $magicString = 'SSL certificate problem:';
             $magicOffset = strpos($exceptionMessage, $magicString);
-            if ($magicOffset !== false) {
+            if ($magicOffset !== false && $verifySsl) {
                 $response = $this->call($targetUrl, false);
 
                 $certificateErrorMessage = trim(substr($exceptionMessage, $magicOffset + strlen($magicString)));

--- a/src/Http/HttpRequester.php
+++ b/src/Http/HttpRequester.php
@@ -3,7 +3,7 @@ namespace Frickelbruder\KickOff\Http;
 
 use Frickelbruder\KickOff\Configuration\TargetUrl;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\TransferStats;
 use GuzzleHttp\Client;
 
@@ -34,14 +34,14 @@ class HttpRequester {
         return $this->cache[ $cacheKey ];
     }
 
-    private function call(TargetUrl $targetUrl) {
+    private function call(TargetUrl $targetUrl, $verifySsl = true) {
         $response = new HttpResponse();
 
         $client = $this->getClient();
         try {
             $websiteResponse = $client->request( $targetUrl->method,
                 $targetUrl->getUrl(),
-                $this->getOptionsArray( $targetUrl, $response )
+                array_merge(array('verify' => $verifySsl), $this->getOptionsArray( $targetUrl, $response ))
             );
             $headers = $this->prepareResponseHeaders( $websiteResponse->getHeaders() );
             $response->setHeaders( $headers );
@@ -49,9 +49,23 @@ class HttpRequester {
             $response->setStatus( $websiteResponse->getStatusCode() );
         } catch(ClientException $e) {
             $websiteResponse = $e->getResponse();
-        } catch(ConnectException $e) {
+        } catch(RequestException $e) {
             $websiteResponse = false;
             $exceptionMessage = $e->getMessage();
+
+            // Check for invalid SSL certificate: If we encounter a certificate error, we will remember
+            // the error message and repeat the request with disabled certificate verification. That way,
+            // a website with an invalid certificate can still be checked.
+            $magicString = 'SSL certificate problem:';
+            $magicOffset = strpos($exceptionMessage, $magicString);
+            if ($magicOffset !== false) {
+                $response = $this->call($targetUrl, false);
+
+                $certificateErrorMessage = trim(substr($exceptionMessage, $magicOffset + strlen($magicString)));
+                $response->setSslCertificateError($certificateErrorMessage);
+
+                return $response;
+            }
         }
 
         if ($websiteResponse) {
@@ -78,7 +92,7 @@ class HttpRequester {
             return $this->client;
         }
 
-        return new Client(array('verify'=>false));
+        return new Client();
     }
 
     /**

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -31,6 +31,11 @@ class HttpResponse {
     private $transferTime = 0.0;
 
     /**
+     * @var string|null
+     */
+    private $sslCertificateError;
+
+    /**
      * @return array
      */
     public function getHeaders() {
@@ -98,5 +103,21 @@ class HttpResponse {
      */
     public function getRequest() {
         return $this->targetUrl;
+    }
+
+    /**
+     * @param string $sslCertificateError
+     */
+    public function setSslCertificateError($sslCertificateError)
+    {
+        $this->sslCertificateError = $sslCertificateError;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSslCertificateError()
+    {
+        return $this->sslCertificateError;
     }
 }

--- a/src/Rules/ValidSslCertificate.php
+++ b/src/Rules/ValidSslCertificate.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Frickelbruder\KickOff\Rules;
+
+class ValidSslCertificate extends RuleBase
+{
+
+    public $name = 'ValidSslCertificate';
+
+    public function validate()
+    {
+        $this->errorMessage = $this->httpResponse->getSslCertificateError();
+
+        return $this->httpResponse->getSslCertificateError() === null;
+    }
+}

--- a/src/config/Rules.yml
+++ b/src/config/Rules.yml
@@ -130,3 +130,6 @@ Rules:
         calls:
             - ["setName", ["ExactlyOneH1TagPresent"]]
             - ["allowMultipleTags", [false]]
+
+    ValidSslCertificate:
+        class: \Frickelbruder\KickOff\Rules\ValidSslCertificate

--- a/tests/Rules/ValidSslCertificateTest.php
+++ b/tests/Rules/ValidSslCertificateTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Frickelbruder\KickOff\Tests\Rules;
+
+use Frickelbruder\KickOff\Http\HttpResponse;
+use Frickelbruder\KickOff\Rules\ValidSslCertificate;
+
+class ValidSslCertificateTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testAcceptsValidCertificate()
+    {
+        $rule = new ValidSslCertificate();
+        $rule->setHttpResponse(new HttpResponse());
+
+        $this->assertTrue($rule->validate());
+    }
+
+
+    public function testDetectsInvalidCertificate()
+    {
+        $errorMessage = 'self signed certificate';
+
+        $response = new HttpResponse();
+        $response->setSslCertificateError($errorMessage);
+
+        $rule = new ValidSslCertificate();
+        $rule->setHttpResponse($response);
+
+        $this->assertFalse($rule->validate());
+        $this->assertEquals($errorMessage, $rule->getErrorMessage());
+    }
+}


### PR DESCRIPTION
This is an alternative implementation to #25 and fixes #22 

Before, the Guzzle `Client` was instantiated with the `verify => false` setting; thus problems with the certificate are ignored. This solution simply turns that back on.

If a certficate problem is detected, the requester will fetch the resource *again*, but this time with `verify => false`. The error message is saved and the actual `ValidSslCertificate` rule only has to check for a stored message.

This are some downsides:

- Testing a website with an invalid certificate will cause two connection attempts per resource. I think this is negligible since the first attempt won’t actually download anything. A possible solution would be to remember problems with a given host in the `HttpRequester` and choose the `verify` setting according to that, but that should be a different task.

- The actual testing logic behind the `ValidSslCertificate` rule is not actually contained in that rule. Since the certificate problem is technically a connection problem, this is pretty much unavoidable without changing the infrastructure even more. Again, for a simple check like this, the solution should be fine.

- This does not check whether the certificate has been revoked through OCSP or CRL. That would require at least one additional lookup.

- The result of this check depends on the system KickOff is run on. Expired certificates rely on correct system time (duh) and the trustworthiness of a certificate is only be checked against the local trust store. If the user modified the trusted root list, this could give false results. Also, trusted roots may vary depending on the operating system and even on the HTTP client used.

 I consider this to be out of scope for KickOff. There are far better solutions for doing a thorough check on a server’s SSL configuration. This rule only serves as a “smoke test”.

-----

Here is an example config for some problematic cases:

```yml
defaults:
    target:
        scheme: https

Sections:
    expired:        { rules: [ValidSslCertificate], config: { host: "expired.badssl.com" } }
    self_signed:    { rules: [ValidSslCertificate], config: { host: "self-signed.badssl.com" } }
    untrusted_root: { rules: [ValidSslCertificate], config: { host: "untrusted-root.badssl.com" } }
    wrong_host:     { rules: [ValidSslCertificate], config: { host: "104.154.89.105" } }
```