### PR TITLE
Add compatibility for Symfony 3.x components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,36 @@
 language: php
+
 php:
 - 7.0
 - 5.6
-- 5.5
+- 5.5.9
+
+matrix:
+  include:
+    - php: 7.0
+      env: dependencies=lowest
+    - php: 5.6
+      env: dependencies=lowest
+    - php: 5.5.9
+      env: dependencies=lowest
+
 before_install:
 - travis_retry composer self-update
 - phpenv config-rm xdebug.ini
+
 install:
-- travis_retry composer install --no-interaction
+- if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; fi;
+- if [ "$dependencies" != "lowest" ]; then composer update --no-interaction; fi;
+
 script: phpunit
+
 before_deploy:
 - composer update --no-dev
 - composer dump-autoload -a
 - echo "phar.readonly = Off" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - curl -LSs https://box-project.github.io/box2/installer.php | php
 - php box.phar build
+
 deploy:
   provider: releases
   api_key:
@@ -24,4 +40,3 @@ deploy:
   on:
     tags: true
     php: 5.5
-

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
   "minimum-stability": "stable",
   "license": "MIT",
   "require": {
-    "php": ">=5.5.0",
-    "symfony/yaml": "~2",
-    "symfony/console": "~2",
+    "php": ">=5.5.9",
+    "symfony/yaml": "~2.7 || ~3.0",
+    "symfony/console": "~2.7 || ~3.0",
     "guzzlehttp/guzzle": "~6"
   },
   "require-dev": {


### PR DESCRIPTION
This allows using KickOff with Symfony 3.x components. Compatibility with 2.7 and 2.8 is still maintained. Lower 2.x versions have reached their end-of-life already and should not have to be supported anymore.

Because of the BC, this doesn’t allow us to use any new features introduced in 3.x versions. But it does allow KickOff to be included in projects that depend on Symfony 3.x components.

Since 3.x components require at least PHP 5.5.9, I increased the previous requirement of 5.5.0 accordingly. Don’t think that will be a problem, though.

I updated the Travis config so that it would always check both the highest and the lowest supported versions of all dependencies. Releases will be built with the highest versions.