### PR TITLE
Added Console Log Listener Test

### DIFF
--- a/bin/kickoff.php
+++ b/bin/kickoff.php
@@ -10,6 +10,7 @@ use Frickelbruder\KickOff\Log\Listener\ConsoleOutputListener;
 use Frickelbruder\KickOff\Log\Logger;
 use Frickelbruder\KickOff\Yaml\Yaml;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../../autoload.php', __DIR__ . '/../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
@@ -25,7 +26,7 @@ $yaml = new Yaml();
 $config = new Configuration($yaml);
 $requester = new HttpRequester();
 $logger = new Logger();
-$logger->addListener('console', new ConsoleOutputListener());
+$logger->addListener('console', new ConsoleOutputListener(new ConsoleOutput));
 $kickoff = new KickOff();
 $kickoff->setConfiguration($config);
 $kickoff->setLogger($logger);

--- a/src/Log/Listener/ConsoleOutputListener.php
+++ b/src/Log/Listener/ConsoleOutputListener.php
@@ -2,28 +2,33 @@
 namespace Frickelbruder\KickOff\Log\Listener;
 
 use Frickelbruder\KickOff\Rules\Interfaces\RuleInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 class ConsoleOutputListener implements Listener {
 
     /**
-     * @var ConsoleOutput
+     * @var ConsoleOutputInterface
      */
-    private $consoleOutput = null;
+    protected $consoleOutput;
+
+    protected $outputPadLength = 80;
 
     private $messages = array();
 
-    private $counter = array('success' => 0, 'errors' => 0);
+    private $counter = array(
+        'success' => 0,
+        'errors' => 0
+    );
 
-    private $outputPadLength = 0;
-    private $outputPadMinLength = 80;
     private $padOutputToLongestMessage = true;
 
-    public function __construct() {
-        $this->consoleOutput = new ConsoleOutput();
-        $this->outputPadLength = $this->outputPadMinLength;
+    /**
+     * ConsoleOutputListener constructor.
+     * @param ConsoleOutputInterface $consoleOutput
+     */
+    public function __construct(ConsoleOutputInterface $consoleOutput) {
+        $this->consoleOutput = $consoleOutput;
     }
-
 
     public function log($sectionName, $targetUrl, RuleInterface $rule, $success) {
         $output = '.';

--- a/src/Log/Listener/CsvLogListener.php
+++ b/src/Log/Listener/CsvLogListener.php
@@ -13,16 +13,12 @@ class CsvLogListener implements Listener {
         $this->logs[] = array($sectionName, $targetUrl, $rule->getName(), $success ? 'Ok' : 'FAILED');
     }
 
-
     public function finish() {
         $handle = fopen($this->logFileName, 'w');
         foreach($this->logs as $log) {
-            fputcsv($handle, $log);
+            fwrite($handle, implode(',', $log) . PHP_EOL);
         }
         fclose($handle);
 
     }
-
-
-
 }

--- a/src/Log/Listener/ListenerFactory.php
+++ b/src/Log/Listener/ListenerFactory.php
@@ -1,6 +1,8 @@
 <?php
 namespace Frickelbruder\KickOff\Log\Listener;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
+
 class ListenerFactory {
 
     /**
@@ -14,7 +16,7 @@ class ListenerFactory {
             case 'junit-file':
                 return new JunitLogListener();
             case 'console':
-                return new ConsoleOutputListener();
+                return new ConsoleOutputListener(new ConsoleOutput);
             case 'csv-file':
                 return new CsvLogListener();
         }

--- a/tests/Log/Listener/ConsoleOutputListenerTest.php
+++ b/tests/Log/Listener/ConsoleOutputListenerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Frickelbruder\KickOff\Tests\Log\Listener;
+
+use Frickelbruder\KickOff\Log\Listener\ConsoleOutputListener;
+use Frickelbruder\KickOff\Tests\Log\RuleStub;
+use Frickelbruder\KickOff\Tests\TestHelper\Console\StringOutput;
+
+
+class ConsoleOutputListenerTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * @var ConsoleOutputListener
+     */
+    private $listener;
+
+    /** @var StringOutput */
+    private $consoleOutput;
+
+    protected function setup() {
+
+        $this->listener = new ConsoleOutputListener;
+        $this->consoleOutput = new StringOutput;
+
+        $consoleOutputReflection = new \ReflectionClass(ConsoleOutputListener::class);
+
+        $outputProperty = $consoleOutputReflection->getProperty('consoleOutput');
+        $outputProperty->setAccessible(true);
+        $outputProperty->setValue($this->listener, $this->consoleOutput);
+    }
+
+    public function testClass() {
+        $rule = new RuleStub();
+        $rule->name='Testcase1';
+        $rule2 = new RuleStub();
+        $rule2->name='Testcase2';
+        $rule3 = new RuleStub();
+        $rule3->name='Testcase3';
+
+        $this->listener->log('Section1', 'http://www.test1.com', $rule, true);
+        $this->listener->log('Section1', 'http://www.test1.com', $rule2, false);
+        $this->listener->log('Section2', 'http://www.test2.com', $rule3, true);
+
+        $this->listener->finish();
+
+        $expectedOutput = file_get_contents(__DIR__ . '/files/console.txt');
+        $this->assertSame($this->consoleOutput->getOutput(), $expectedOutput);
+    }
+}

--- a/tests/Log/Listener/ConsoleOutputListenerTest.php
+++ b/tests/Log/Listener/ConsoleOutputListenerTest.php
@@ -6,7 +6,6 @@ use Frickelbruder\KickOff\Log\Listener\ConsoleOutputListener;
 use Frickelbruder\KickOff\Tests\Log\RuleStub;
 use Frickelbruder\KickOff\Tests\TestHelper\Console\StringOutput;
 
-
 class ConsoleOutputListenerTest extends \PHPUnit_Framework_TestCase {
 
     /**
@@ -18,15 +17,8 @@ class ConsoleOutputListenerTest extends \PHPUnit_Framework_TestCase {
     private $consoleOutput;
 
     protected function setup() {
-
-        $this->listener = new ConsoleOutputListener;
         $this->consoleOutput = new StringOutput;
-
-        $consoleOutputReflection = new \ReflectionClass(ConsoleOutputListener::class);
-
-        $outputProperty = $consoleOutputReflection->getProperty('consoleOutput');
-        $outputProperty->setAccessible(true);
-        $outputProperty->setValue($this->listener, $this->consoleOutput);
+        $this->listener = new ConsoleOutputListener($this->consoleOutput);
     }
 
     public function testClass() {
@@ -44,6 +36,6 @@ class ConsoleOutputListenerTest extends \PHPUnit_Framework_TestCase {
         $this->listener->finish();
 
         $expectedOutput = file_get_contents(__DIR__ . '/files/console.txt');
-        $this->assertSame($this->consoleOutput->getOutput(), $expectedOutput);
+        $this->assertSame($expectedOutput, $this->consoleOutput->getOutput());
     }
 }

--- a/tests/Log/Listener/files/console.txt
+++ b/tests/Log/Listener/files/console.txt
@@ -1,0 +1,7 @@
+.<error>F</error>.
+<error>                                                                                </error>
+<error>  Section1                                                                      </error>
+<error>    Testcase2: This Rule did not yield the expected result.                     </error>
+<error>                                                                                </error>
+
+Fail (3 Tests 2 passed, 1 failed)

--- a/tests/TestHelper/Console/StringOutput.php
+++ b/tests/TestHelper/Console/StringOutput.php
@@ -2,6 +2,8 @@
 
 namespace Frickelbruder\KickOff\Tests\TestHelper\Console;
 
+use Symfony\Component\Console\Output\ConsoleOutput;
+
 /**
  * Class StringOutput
  *
@@ -9,23 +11,19 @@ namespace Frickelbruder\KickOff\Tests\TestHelper\Console;
  *
  * @package Frickelbruder\KickOff\Tests\TestHelper\Console
  */
-class StringOutput {
+class StringOutput extends ConsoleOutput {
 
     /** @var string */
     private $output = '';
 
-    /**
-     * @param $content
-     */
-    public function write($content) {
-        $this->output .= $content;
+    public function writeln($messages, $options = self::OUTPUT_NORMAL)
+    {
+        $this->output .= $messages . PHP_EOL;
     }
 
-    /**
-     * @param $content
-     */
-    public function writeln($content) {
-        $this->output .= $content . PHP_EOL;
+    public function write($messages, $newline = false, $options = self::OUTPUT_NORMAL)
+    {
+        $this->output .= $messages;
     }
 
     /**

--- a/tests/TestHelper/Console/StringOutput.php
+++ b/tests/TestHelper/Console/StringOutput.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Frickelbruder\KickOff\Tests\TestHelper\Console;
+
+/**
+ * Class StringOutput
+ *
+ * Helper Class to Output Console Content as String
+ *
+ * @package Frickelbruder\KickOff\Tests\TestHelper\Console
+ */
+class StringOutput {
+
+    /** @var string */
+    private $output = '';
+
+    /**
+     * @param $content
+     */
+    public function write($content) {
+        $this->output .= $content;
+    }
+
+    /**
+     * @param $content
+     */
+    public function writeln($content) {
+        $this->output .= $content . PHP_EOL;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutput() {
+        return $this->output;
+    }
+}


### PR DESCRIPTION
This PR adds a TestCase for the Console Listener.
It's not the best approach but as the class uses ``new Classname`` we have no choice.
Still better than no test.

This PR:

- [x] adds a console test
- [x] fixes EOL on different systems